### PR TITLE
Add get_chains to Defillama class

### DIFF
--- a/messari/defillama/defillama.py
+++ b/messari/defillama/defillama.py
@@ -272,8 +272,9 @@ class DeFiLlama(DataLoader):
         """
         chains = self.get_response(DL_CHAINS_URL)
 
-        chain_names = []
-        for chain in chains:
-            chain_names.append(chain['name'])
+        chain_names = [chain['name'] for chain in chains]
+
+        # Sort chain name results to ensure consistent order
+        chain_names = sorted(chain_names)
 
         return chain_names

--- a/messari/defillama/defillama.py
+++ b/messari/defillama/defillama.py
@@ -20,6 +20,7 @@ DL_GLOBAL_TVL_URL = "https://api.llama.fi/charts/"
 DL_CURRENT_PROTOCOL_TVL_URL = Template("https://api.llama.fi/tvl/$slug")
 DL_CHAIN_TVL_URL = Template("https://api.llama.fi/charts/$chain")
 DL_GET_PROTOCOL_TVL_URL = Template("https://api.llama.fi/protocol/$slug")
+DL_CHAINS_URL = "https://api.llama.fi/chains/"
 
 
 class DeFiLlama(DataLoader):
@@ -258,3 +259,21 @@ class DeFiLlama(DataLoader):
 
         protocols_df = pd.DataFrame(protocol_dict)
         return protocols_df
+
+    def get_chains(self) -> List[str]:
+        """Get the names of all chains supported by Defi Llama
+
+        Used downstream to get the names/TVL of protocols on each chain
+
+        Returns
+        -------
+        List
+            List of chain name strings
+        """
+        chains = self.get_response(DL_CHAINS_URL)
+
+        chain_names = []
+        for chain in chains:
+            chain_names.append(chain['name'])
+
+        return chain_names


### PR DESCRIPTION
## Summary
Adding another method to the `Defillama` class to consume the output from the `/chains` API [endpoint](https://defillama.com/docs/api). 

This will allow us to programmatically get the TVL and/or names of all protocols for a specific chain.

Sorting the results to ensure that they're returned consistently between runs.

## Tests
Using the `get_chains()` method and consuming the results in `get_chain_tvl_timeseries()`
<img width="684" alt="image" src="https://user-images.githubusercontent.com/29241719/172202304-e31369e0-6709-4833-ae91-49f580edddcf.png">
