### PR TITLE
[Easy] Add empty chain TVL dataframe check

### DIFF
--- a/messari/defillama/defillama.py
+++ b/messari/defillama/defillama.py
@@ -210,6 +210,11 @@ class DeFiLlama(DataLoader):
 
         # Join DataFrames from each chain & return
         chains_df = pd.concat(chain_df_list, axis=1)
+
+        # If chains_df is empty, return an empty DataFrame
+        if chains_df.empty:
+            return pd.DataFrame()
+
         chains_df.columns = chains
         chains_df = time_filter_df(chains_df, start_date=start_date, end_date=end_date)
         return chains_df


### PR DESCRIPTION
- When grabbing data from `get_chain_tvl_timeseries()` for certain chains, the global TVL data can come back empty (ran into this for `OntologyEVM`)
- To fix this, check to see if the global TVL results are empty and return an empty `pd.DataFrame` before assigning column names.

Results before the check
<img width="1506" alt="Screen Shot 2022-06-06 at 3 42 23 PM" src="https://user-images.githubusercontent.com/29241719/172235820-3e6e7ca2-ee82-4fc8-9f21-ef0d0171f060.png">

Results after the check is aded
<img width="985" alt="Screen Shot 2022-06-06 at 3 41 09 PM" src="https://user-images.githubusercontent.com/29241719/172235870-849ae4b6-02dd-4853-863c-225b734a2c0c.png">


`get_chain_tvl_timeseries()` works for all chains returned when calling the `/chains` [endpoint](https://defillama.com/docs/api) on Defillama
<img width="597" alt="image" src="https://user-images.githubusercontent.com/29241719/172245316-a018eaa8-a42a-4775-b372-19e3e8d13c22.png">

