### PR TITLE
Convert Coingecko Volume Output to USD 

### DIFF
--- a/messari/coingecko/coingecko.py
+++ b/messari/coingecko/coingecko.py
@@ -87,10 +87,11 @@ class CoinGecko(DataLoader):
         df = pd.Series(response).to_frame(name=coin_id)
         return df
 
-    def get_coin_chart(self, coin_id: str, days: str='max') -> pd.DataFrame:
+    def get_coin_chart(self, coin_id: str, interval: int = 'daily', days: str='max') -> pd.DataFrame:
         url = f'{BASE_URL}/coins/{coin_id}/market_chart'
         parameters = {
                 'vs_currency': 'usd',
+                'interval': interval,
                 'days': days
                 }
         response = self.get_response(url, params=parameters)


### PR DESCRIPTION
- The initial implementation of the Coingecko exchange volume endpoint was reporting it in BTC terms only 
- Calling `get_exchange_volume` will not report the daily volume in both BTC and USD terms
- Adding example for `traderjoe`